### PR TITLE
Fix CIT scanning to support optional minecraft: namespace

### DIFF
--- a/src/client/java/lc/cit/list/CitScanner.java
+++ b/src/client/java/lc/cit/list/CitScanner.java
@@ -51,8 +51,9 @@ public class CitScanner {
                         String property = model.get("property").getAsString();
                         String component = model.get("component").getAsString();
 
-                        if (!"minecraft:component".equals(property)
-                                || !"minecraft:custom_name".equals(component))
+                        if (!(property.equals("minecraft:component") || property.equals("component")))
+                            continue;
+                        if (!(component.equals("minecraft:custom_name") || component.equals("custom_name")))
                             continue;
 
                         // Extract CIT cases
@@ -117,8 +118,11 @@ public class CitScanner {
 
         if (element.isJsonObject()) {
             JsonObject obj = element.getAsJsonObject();
-            if (obj.has("type") && "minecraft:select".equals(obj.get("type").getAsString())) {
-                found.add(obj);
+            if (obj.has("type")) {
+                String type = obj.get("type").getAsString();
+                if ("minecraft:select".equals(type) || "select".equals(type)) {
+                    found.add(obj);
+                }
             }
             for (Map.Entry<String, JsonElement> e : obj.entrySet()) {
                 found.addAll(findSelectBlocks(e.getValue()));


### PR DESCRIPTION
## Problem
The CIT scanner currently only detects definitions that use the explicit `minecraft:` namespace (e.g., `"type": "minecraft:select"`, `"property": "minecraft:component"`).

However, Minecraft also accepts shorthand notation without the namespace prefix (e.g., `"type": "select"`, `"property": "component"`), which defaults to the `minecraft:` namespace. This causes the scanner to miss CIT definitions in resource packs that use this shorthand format.

## Solution
Updated the scanning logic to accept both namespaced and non-namespaced formats:

- Modified `findSelectBlocks()` to recognize both `"select"` and `"minecraft:select"` type values
- Updated property validation to accept both `"component"` and `"minecraft:component"`
- Updated component validation to accept both `"custom_name"` and `"minecraft:custom_name"`

## Testing
Tested with resource packs using both formats:
- Explicit namespace: `"type": "minecraft:select"`, `"property": "minecraft:component"`
- Shorthand: `"type": "select"`, `"property": "component"`

Both formats are now correctly detected and listed.

## Changes
- `CitScanner.java`: Updated type and property matching logic to support optional namespace prefix