### PR TITLE
Fix CIT scanning to support multiple trigger names in "when" field

### DIFF
--- a/src/client/java/lc/cit/list/CitScanner.java
+++ b/src/client/java/lc/cit/list/CitScanner.java
@@ -73,13 +73,31 @@ public class CitScanner {
                                 JsonObject caseObj = el.getAsJsonObject();
 
                                 if (caseObj.has("when")) {
-                                    String when = caseObj.get("when").getAsString();
-                                    nameList.add(itemName);
-                                    conditionList.add(when);
-                                    packList.add(packName);
+                                    JsonElement whenElement = caseObj.get("when");
+                                    List<String> whenValues = new ArrayList<>();
+                                    
+                                    // Handle both string and array formats
+                                    if (whenElement.isJsonPrimitive()) {
+                                        whenValues.add(whenElement.getAsString());
+                                    } else if (whenElement.isJsonArray()) {
+                                        JsonArray whenArray = whenElement.getAsJsonArray();
+                                        for (JsonElement nameEl : whenArray) {
+                                            if (nameEl.isJsonPrimitive()) {
+                                                whenValues.add(nameEl.getAsString());
+                                            }
+                                        }
+                                    }
+                                    
+                                    // Add an entry for each possible name
                                     String ite = id.getPath().replace(".json", "");
                                     ite = ite.replaceFirst(".*/", "");
-                                    resultItem.add(ite);
+                                    
+                                    for (String when : whenValues) {
+                                        nameList.add(itemName);
+                                        conditionList.add(when);
+                                        packList.add(packName);
+                                        resultItem.add(ite);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Problem
The CIT scanner fails to parse item models that define multiple trigger names for a single CIT variant, resulting in parsing errors and missing entries in the list.

### Error Messages
```
[CIT Scanner] Error parsing minecraft:items/white_bundle.json: Array must have size 1, but has size 8
[CIT Scanner] Error parsing minecraft:items/wooden_spear.json: Array must have size 1, but has size 2
[CIT Scanner] Error parsing minecraft:items/wooden_sword.json: Array must have size 1, but has size 2
```

### Root Cause
The code assumes the `"when"` field in CIT cases is always a single string value and calls `.getAsString()` directly. However, Minecraft's item model format supports both:

**Single trigger name (currently supported):**
```json
{
  "when": "Persian Persuader",
  "model": { ... }
}
```

**Multiple trigger names (currently broken):**
```json
{
  "when": [
    "Christmas Gift",
    "christmas gift",
    "Gift", 
    "gift",
    "Present",
    "present",
    "White Gift",
    "white gift"
  ],
  "model": { ... }
}
```

When the scanner encounters an array, `getAsString()` throws an exception, causing the entire item to be skipped.

## Solution
Modified the `"when"` field parsing logic to detect and handle both string and array formats:

1. Check if `"when"` is a primitive (string) or array
2. For strings: extract the single value as before
3. For arrays: iterate through all string elements
4. Create a separate list entry for each trigger name

This approach ensures users can see all possible names that will activate a CIT texture, making the list more comprehensive and useful.

### Code Changes
- Lines 75-98: Replaced direct `.getAsString()` call with format detection logic
- Added `whenValues` list to collect all trigger names (single or multiple)
- Loop through collected names to create individual entries

## Testing
Tested with resource packs containing:
- Single trigger names (backward compatibility maintained)
- Multiple trigger names in arrays (now works correctly)
- Mixed resource packs with both formats

All previously failing item models now parse successfully. The list displays each possible trigger name as a separate entry, grouped by item and resource pack.

### Example Output
Before this fix, items with multiple trigger names would fail to parse and not appear in the list. After the fix, all trigger names are displayed:

![Screenshot showing white_bundle with multiple trigger names listed](https://github.com/user-attachments/assets/c6df8b0c-2012-4617-960c-bf14d417f88c)


## Note
This PR targets 1.21.10. A companion PR for 1.21.11 will be submitted separately.