### PR TITLE
Fix CIT scanning to support multiple trigger names in "when" field (1.21.11)

### DIFF
--- a/src/client/java/lc/cit/list/CitScanner.java
+++ b/src/client/java/lc/cit/list/CitScanner.java
@@ -18,7 +18,6 @@ public class CitScanner {
      * Returns entries in format: ItemName_NameToTriggerCIT_ResourcePack
      */
     public static String[][] getAllCustomNameCITs() {
-        List<String> resultItem = new ArrayList<>();
         ResourceManager rm = Minecraft.getInstance().getResourceManager();
         List<String> nameList = new ArrayList<>();
         List<String> conditionList = new ArrayList<>();
@@ -71,13 +70,27 @@ public class CitScanner {
                                 JsonObject caseObj = el.getAsJsonObject();
 
                                 if (caseObj.has("when")) {
-                                    String when = caseObj.get("when").getAsString();
-                                    nameList.add(itemName);
-                                    conditionList.add(when);
-                                    packList.add(packName);
-                                    String ite = id.getPath().replace(".json", "");
-                                    ite = ite.replaceFirst(".*/", "");
-                                    resultItem.add(ite);
+                                    JsonElement whenElement = caseObj.get("when");
+                                    List<String> whenValues = new ArrayList<>();
+                                    
+                                    // Handle both string and array formats
+                                    if (whenElement.isJsonPrimitive()) {
+                                        whenValues.add(whenElement.getAsString());
+                                    } else if (whenElement.isJsonArray()) {
+                                        JsonArray whenArray = whenElement.getAsJsonArray();
+                                        for (JsonElement nameEl : whenArray) {
+                                            if (nameEl.isJsonPrimitive()) {
+                                                whenValues.add(nameEl.getAsString());
+                                            }
+                                        }
+                                    }
+                                    
+                                    // Add an entry for each possible name
+                                    for (String when : whenValues) {
+                                        nameList.add(itemName);
+                                        conditionList.add(when);
+                                        packList.add(packName);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Related PR
This is the 1.21.11 version of #12 which fixes the same issue for 1.21.10.

## Problem
The CIT scanner fails to parse item models that define multiple trigger names for a single CIT variant, resulting in parsing errors and missing entries in the list.

### Error Messages
```
[CIT Scanner] Error parsing minecraft:items/white_bundle.json: Array must have size 1, but has size 8
[CIT Scanner] Error parsing minecraft:items/wooden_spear.json: Array must have size 1, but has size 2
```

### Root Cause
The code assumes the `"when"` field is always a single string and calls `.getAsString()` directly. However, Minecraft's item model format supports both single strings and arrays of strings for multiple trigger names.

## Solution
Modified the `"when"` field parsing to detect and handle both formats:
- For single strings: extract the value as before
- For arrays: iterate through all string elements and create an entry for each

### Changes for 1.21.11
- Lines 73-91: Added array handling logic for the `"when"` field
- Removed unused `resultItem` list variable
- Adapted fix to work with the refactored CitScanner structure (String[][] return type, updated Minecraft API calls)

## Testing
Tested with resource packs containing:
- Single trigger names (backward compatibility maintained)
- Multiple trigger names in arrays (now works correctly)

All previously failing item models now parse successfully.

![Screenshot showing the fix working](https://github.com/user-attachments/assets/04494389-fc54-410f-bb62-5e68a16eb776)